### PR TITLE
fix: Downgrade datastore-preferences to 1.1.7 for 16KB compatibility

### DIFF
--- a/flutter_secure_storage_x/android/build.gradle
+++ b/flutter_secure_storage_x/android/build.gradle
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation("androidx.datastore:datastore-preferences:1.2.0")
+        implementation("androidx.datastore:datastore-preferences:1.1.7")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
         testImplementation("org.jetbrains.kotlin:kotlin-test")


### PR DESCRIPTION
fix https://github.com/koji-1009/flutter_secure_storage/issues/105