### PR TITLE
docs(android): drop stale v12-era Recommended Configuration note

### DIFF
--- a/flutter_secure_storage_x/README.md
+++ b/flutter_secure_storage_x/README.md
@@ -47,10 +47,6 @@ The following table outlines the evolution of storage and encryption on Android,
 > 1. Update the app to **v12** and release it.
 > 2. Ensure users launch the v12 app to complete the internal data migration to KeyStore (migration happens automatically on first launch in v12).
 > 3. After a sufficient migration period, update to **v13** (DataStore default).
->
-> **Recommended Configuration:**
-> In v13, `DataStore` becomes the default storage backend.
-> We recommend explicitly enabling `AndroidOptions(dataStore: true)` in v12 (instead of `encryptedSharedPreferences: true`). This allows you to complete both data migration and backend modernization in the v12 phase, making the transition to v13 smoother.
 
 ### Summary
 


### PR DESCRIPTION
The note advised enabling AndroidOptions(dataStore: true) "in v12" to smooth the v13 transition. With v13 already published, that guidance addresses a phase users can no longer act on, so it adds noise to the v12 -> v13 migration warning rather than helping. The migration steps above remain accurate without it.