### PR TITLE
feat(windows): migrate to win32 ^6.0.1

### DIFF
--- a/flutter_secure_storage_x/example/pubspec.yaml
+++ b/flutter_secure_storage_x/example/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none'
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x/pubspec.yaml
+++ b/flutter_secure_storage_x/pubspec.yaml
@@ -6,8 +6,8 @@ version: 13.0.1
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 flutter:
   plugin:

--- a/flutter_secure_storage_x_linux/pubspec.yaml
+++ b/flutter_secure_storage_x_linux/pubspec.yaml
@@ -6,8 +6,8 @@ version: 1.5.2
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x_macos/pubspec.yaml
+++ b/flutter_secure_storage_x_macos/pubspec.yaml
@@ -6,8 +6,8 @@ version: 3.5.2
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x_platform_interface/pubspec.yaml
+++ b/flutter_secure_storage_x_platform_interface/pubspec.yaml
@@ -6,8 +6,8 @@ version: 2.0.0
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x_web/pubspec.yaml
+++ b/flutter_secure_storage_x_web/pubspec.yaml
@@ -6,8 +6,8 @@ version: 2.2.2
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x_windows/example/pubspec.yaml
+++ b/flutter_secure_storage_x_windows/example/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: 'none'
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_x_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/flutter_secure_storage_x_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -213,26 +213,24 @@ class DpapiJsonFileMapStorage extends MapStorage {
         final Pointer<CRYPT_INTEGER_BLOB> plainTextBlob = alloc.allocate(
           sizeOf<CRYPT_INTEGER_BLOB>(),
         );
-        if (CryptUnprotectData(
-              encryptedTextBlob,
-              nullptr,
-              nullptr,
-              nullptr,
-              nullptr,
-              0,
-              plainTextBlob,
-            ) ==
-            0) {
+        final decryptResult = CryptUnprotectData(
+          encryptedTextBlob,
+          null,
+          null,
+          null,
+          0,
+          plainTextBlob,
+        );
+        if (!decryptResult.value) {
           throw WindowsException(
-            GetLastError(),
+            decryptResult.error.toHRESULT(),
             message: 'Failure on CryptUnprotectData()',
           );
         }
 
         if (plainTextBlob.ref.pbData.address == NULL) {
           throw WindowsException(
-            // ignore: deprecated_member_use
-            WIN32_ERROR.ERROR_OUTOFMEMORY,
+            ERROR_OUTOFMEMORY.toHRESULT(),
             message: 'Failure on CryptUnprotectData()',
           );
         }
@@ -243,9 +241,10 @@ class DpapiJsonFileMapStorage extends MapStorage {
           );
         } finally {
           if (plainTextBlob.ref.pbData.address != NULL) {
-            if (LocalFree(plainTextBlob.ref.pbData).address != NULL) {
+            final freeResult = LocalFree(HLOCAL(plainTextBlob.ref.pbData));
+            if (freeResult.value.address != NULL) {
               debugPrint(
-                'load: Failed to LocalFree with: 0x${GetLastError().toHexString(32)}',
+                'load: Failed to LocalFree with: ${freeResult.error.toHexString(32)}',
               );
             }
           }
@@ -317,26 +316,24 @@ class DpapiJsonFileMapStorage extends MapStorage {
       final Pointer<CRYPT_INTEGER_BLOB> encryptedTextBlob = alloc.allocate(
         sizeOf<CRYPT_INTEGER_BLOB>(),
       );
-      if (CryptProtectData(
-            plainTextBlob,
-            nullptr,
-            nullptr,
-            nullptr,
-            nullptr,
-            0,
-            encryptedTextBlob,
-          ) ==
-          0) {
+      final protectResult = CryptProtectData(
+        plainTextBlob,
+        null,
+        null,
+        null,
+        0,
+        encryptedTextBlob,
+      );
+      if (!protectResult.value) {
         throw WindowsException(
-          GetLastError(),
+          protectResult.error.toHRESULT(),
           message: 'Failure on CryptProtectData()',
         );
       }
 
       if (encryptedTextBlob.ref.pbData.address == NULL) {
         throw WindowsException(
-          // ignore: deprecated_member_use
-          WIN32_ERROR.ERROR_OUTOFMEMORY,
+          ERROR_OUTOFMEMORY.toHRESULT(),
           message: 'Failure on CryptProtectData()',
         );
       }
@@ -363,9 +360,10 @@ class DpapiJsonFileMapStorage extends MapStorage {
         }
       } finally {
         if (encryptedTextBlob.ref.pbData.address != NULL) {
-          if (LocalFree(encryptedTextBlob.ref.pbData).address != NULL) {
+          final freeResult = LocalFree(HLOCAL(encryptedTextBlob.ref.pbData));
+          if (freeResult.value.address != NULL) {
             debugPrint(
-              'save: Failed to LocalFree with: 0x${GetLastError().toHexString(32)}',
+              'save: Failed to LocalFree with: ${freeResult.error.toHexString(32)}',
             );
           }
         }

--- a/flutter_secure_storage_x_windows/pubspec.yaml
+++ b/flutter_secure_storage_x_windows/pubspec.yaml
@@ -6,8 +6,8 @@ version: 3.4.2
 resolution: workspace
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   ffi: ^2.0.0
@@ -16,7 +16,7 @@ dependencies:
   flutter_secure_storage_x_platform_interface: ^2.0.0
   path: ^1.8.0
   path_provider: ^2.0.0
-  win32: ^5.5.1
+  win32: ^6.0.1
 
 dev_dependencies:
   flutter_test:

--- a/flutter_secure_storage_x_windows/test/unit_test.dart
+++ b/flutter_secure_storage_x_windows/test/unit_test.dart
@@ -17,6 +17,10 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   FutureOr<void> cleanUpFiles() async {
+    if (!Platform.isWindows) {
+      return;
+    }
+
     // Clean up current & legacy files.
     final directory = await getApplicationSupportDirectory();
     if (directory.existsSync()) {
@@ -811,52 +815,58 @@ void main() {
       }),
     );
 
-    test('write - new', () async {
-      const key = 'KEY';
-      const value = 'VALUE';
+    test(
+      'write - new',
+      () => withFfi(() async {
+        const key = 'KEY';
+        const value = 'VALUE';
 
-      var deleteCalled = 0;
-      final target = createTarget((call) async {
-        if (call.method == 'delete') {
-          deleteCalled++;
-          return null;
-        }
+        var deleteCalled = 0;
+        final target = createTarget((call) async {
+          if (call.method == 'delete') {
+            deleteCalled++;
+            return null;
+          }
 
-        fail('Unexpected method call: ${call.method}');
-      });
-      final options = createOptions();
-      await target.write(key: key, value: value, options: options);
-      expect(deleteCalled, 1);
+          fail('Unexpected method call: ${call.method}');
+        });
+        final options = createOptions();
+        await target.write(key: key, value: value, options: options);
+        expect(deleteCalled, 1);
 
-      final result = await target.read(key: key, options: options);
-      expect(result, value);
-      expect(deleteCalled, 2);
-    });
+        final result = await target.read(key: key, options: options);
+        expect(result, value);
+        expect(deleteCalled, 2);
+      }),
+    );
 
-    test('write - overwrite', () async {
-      const key = 'KEY';
-      const value1 = 'VALUE1';
-      const value2 = 'VALUE2';
+    test(
+      'write - overwrite',
+      () => withFfi(() async {
+        const key = 'KEY';
+        const value1 = 'VALUE1';
+        const value2 = 'VALUE2';
 
-      var deleteCalled = 0;
-      final target = createTarget((call) async {
-        if (call.method == 'delete') {
-          deleteCalled++;
-          return null;
-        }
+        var deleteCalled = 0;
+        final target = createTarget((call) async {
+          if (call.method == 'delete') {
+            deleteCalled++;
+            return null;
+          }
 
-        fail('Unexpected method call: ${call.method}');
-      });
-      final options = createOptions();
-      await target.write(key: key, value: value1, options: options);
-      expect(deleteCalled, 1);
-      await target.write(key: key, value: value2, options: options);
-      expect(deleteCalled, 2);
+          fail('Unexpected method call: ${call.method}');
+        });
+        final options = createOptions();
+        await target.write(key: key, value: value1, options: options);
+        expect(deleteCalled, 1);
+        await target.write(key: key, value: value2, options: options);
+        expect(deleteCalled, 2);
 
-      final result = await target.read(key: key, options: options);
-      expect(result, value2);
-      expect(deleteCalled, 3);
-    });
+        final result = await target.read(key: key, options: options);
+        expect(result, value2);
+        expect(deleteCalled, 3);
+      }),
+    );
 
     test(
       'delete - exists, any',
@@ -983,6 +993,11 @@ void main() {
     Map<String, String> createOptions() => {'useBackwardCompatibility': 'true'};
 
     Future<void> testSpecialCharactor(String key, {String? value}) async {
+      // Exercises the real DPAPI storage path; Windows only (see canTest).
+      if (!canTest()) {
+        return;
+      }
+
       final target = createTarget();
       final options = createOptions();
 
@@ -1024,39 +1039,42 @@ void main() {
     );
     test('Empty key & value', () => testSpecialCharactor('', value: ''));
 
-    test('Only casing is differ', () async {
-      final target = createTarget();
-      final options = createOptions();
-      const key1 = 'KEY';
-      const key2 = 'key';
-      const value1 = 'Value1';
-      const value2 = 'Value2';
+    test(
+      'Only casing is differ',
+      () => withFfi(() async {
+        final target = createTarget();
+        final options = createOptions();
+        const key1 = 'KEY';
+        const key2 = 'key';
+        const value1 = 'Value1';
+        const value2 = 'Value2';
 
-      await target.write(key: key1, value: value1, options: options);
-      await target.write(key: key2, value: value2, options: options);
-      final results = await target.readAll(options: options);
-      expect(results.length, 2);
-      expect(results[key1], value1);
-      expect(results[key2], value2);
+        await target.write(key: key1, value: value1, options: options);
+        await target.write(key: key2, value: value2, options: options);
+        final results = await target.readAll(options: options);
+        expect(results.length, 2);
+        expect(results[key1], value1);
+        expect(results[key2], value2);
 
-      expect(await target.read(key: key1, options: options), value1);
-      expect(await target.read(key: key2, options: options), value2);
-      expect(await target.containsKey(key: key1, options: options), isTrue);
-      expect(await target.containsKey(key: key2, options: options), isTrue);
+        expect(await target.read(key: key1, options: options), value1);
+        expect(await target.read(key: key2, options: options), value2);
+        expect(await target.containsKey(key: key1, options: options), isTrue);
+        expect(await target.containsKey(key: key2, options: options), isTrue);
 
-      await target.delete(key: key1, options: options);
-      expect(await target.read(key: key1, options: options), isNull);
-      expect(await target.read(key: key2, options: options), value2);
-      expect(await target.containsKey(key: key1, options: options), isFalse);
-      expect(await target.containsKey(key: key2, options: options), isTrue);
+        await target.delete(key: key1, options: options);
+        expect(await target.read(key: key1, options: options), isNull);
+        expect(await target.read(key: key2, options: options), value2);
+        expect(await target.containsKey(key: key1, options: options), isFalse);
+        expect(await target.containsKey(key: key2, options: options), isTrue);
 
-      await target.write(key: key2, value: value2, options: options);
-      await target.deleteAll(options: options);
-      expect(await target.read(key: key1, options: options), isNull);
-      expect(await target.read(key: key2, options: options), isNull);
-      expect(await target.containsKey(key: key1, options: options), isFalse);
-      expect(await target.containsKey(key: key2, options: options), isFalse);
-    });
+        await target.write(key: key2, value: value2, options: options);
+        await target.deleteAll(options: options);
+        expect(await target.read(key: key1, options: options), isNull);
+        expect(await target.read(key: key2, options: options), isNull);
+        expect(await target.containsKey(key: key1, options: options), isFalse);
+        expect(await target.containsKey(key: key2, options: options), isFalse);
+      }),
+    );
   });
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_secure_storage_x_root
 repository: https://github.com/koji-1009/flutter_secure_storage
 
 environment:
-  sdk: '>=3.9.0 <4.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 
 workspace:
   - flutter_secure_storage_x
@@ -22,13 +22,13 @@ melos:
   command:
     bootstrap:
       environment:
-        sdk: '>=3.9.0 <4.0.0'
-        flutter: '>=3.35.0'
+        sdk: '>=3.10.0 <4.0.0'
+        flutter: '>=3.38.0'
       dependencies:
         ffi: ^2.0.0
         path: ^1.8.0
         path_provider: ^2.0.0
         web: ^1.0.0
-        win32: ^5.5.1
+        win32: ^6.0.1
       dev_dependencies:
         flutter_lints: ^6.0.0


### PR DESCRIPTION
Upgrade win32 from ^5.5.1 to ^6.0.1, which adopts the new Win32Result API and requires Dart SDK >=3.10.0.

- Adapt CryptProtectData/CryptUnprotectData/LocalFree to the Win32Result<T> return type (.value/.error) and the HLOCAL wrapper.
- Raise the SDK lower bound to >=3.10.0 across the workspace.
- Gate native DPAPI tests behind withFfi/canTest so the suite runs off-Windows.