### PR TITLE
ci: bump CI JDK to 21 for AGP 9

### DIFF
--- a/.github/workflows/flutter_drive.yml
+++ b/.github/workflows/flutter_drive.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -73,7 +73,7 @@ jobs:
           boot_timeout_seconds: 180
       - name: Run flutter integration tests
         working-directory: flutter_secure_storage_x/example
-        run: flutter test integration_test -d ${{ steps.simulator.outputs.udid }} --verbose
+        run: flutter test integration_test -d ${{ steps.simulator.outputs.udid }}
 
   drive_linux:
     name: Linux


### PR DESCRIPTION
> **Stacked on #118 (which is stacked on #119).** Merge order: #119 → #118 → this PR; GitHub retargets the base to `main` automatically as each lands.

## Summary

CI tweaks accompanying the Flutter 3.44 / AGP 9 work:

- Bump the Android job's `setup-java` to JDK **21** (AGP 9 builds need a modern JDK).
- Drop `--verbose` from the iOS integration test run to reduce log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)